### PR TITLE
 Removes the Claim/Unclaim buttons so that teams cannot claim/unclaim…

### DIFF
--- a/elm/src/View.elm
+++ b/elm/src/View.elm
@@ -73,8 +73,7 @@ lockActionButton f pool lock =
         action =
             lockAction pool lock
     in
-    a [ href "#", onClick (PerformLockAction action) ] [ text (toSymbol action) ]
-
+    text "Locks can only be viewed. To Claim/Unclaim please ping the PKS-RelEng team"
 
 lockedBy : LockOwner -> String
 lockedBy o =


### PR DESCRIPTION
… locks and cause confusion about lock ownership

@akshaymankar The idea is to remove the claim/unclaim buttons on el-patron for locks related to releng. Is my commit good enough or should I be deleting lines 57-60 in View.elm as well.

Thanks

Sudhindra.